### PR TITLE
Fix undefined market bonus

### DIFF
--- a/src/app/Services/words.service.ts
+++ b/src/app/Services/words.service.ts
@@ -922,7 +922,7 @@ export class WordsService {
     const lettersBonus = this.gameService.game().lettersBonus;
     var letters = word.toLowerCase().split('');
     var points = 0;
-    let marketBonus: number[] = [];
+    let marketBonus: number[] = [0, 0, 0, 0, 0, 0, 0, 0];
     if (GameUtils.IsPurchasedUpgrade(this.gameService.game(), 'Mark')) {
       marketBonus = this.marketService.letterBonus();
     }


### PR DESCRIPTION
## Summary
- prevent `marketBonus` from being empty in `WordsService`

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684399645350832abb3a89852ddfdfb6