### PR TITLE
Fix pipe semicolon and add tests

### DIFF
--- a/src/app/Pipes/exponential-number.pipe.spec.ts
+++ b/src/app/Pipes/exponential-number.pipe.spec.ts
@@ -4,4 +4,14 @@ describe('ExponentialNumberPipe', () => {
     const pipe = new ExponentialNumberPipe();
     expect(pipe).toBeTruthy();
   });
+
+  it('returns fixed string for small numbers', () => {
+    const pipe = new ExponentialNumberPipe();
+    expect(pipe.transform(12345)).toBe('12345');
+  });
+
+  it('returns exponential string for large numbers', () => {
+    const pipe = new ExponentialNumberPipe();
+    expect(pipe.transform(1234567)).toBe('1.23e+6');
+  });
 });

--- a/src/app/Pipes/exponential-number.pipe.ts
+++ b/src/app/Pipes/exponential-number.pipe.ts
@@ -6,7 +6,9 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class ExponentialNumberPipe implements PipeTransform {
 
   transform(value: number): string {
-    return value.toFixed(0).toString().length <= 6 ? value.toFixed(0).toString() : value.toExponential(2).toString();;
+    return value.toFixed(0).toString().length <= 6
+      ? value.toFixed(0).toString()
+      : value.toExponential(2).toString();
   }
 
 }


### PR DESCRIPTION
## Summary
- remove extra semicolon from `exponential-number.pipe`
- add tests verifying fixed vs exponential formatting

## Testing
- `npx ng test --no-watch --no-progress` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_e_6843a455d2d8832ab826e0c701889b63