### PR TITLE
Fix constructor usage in unit tests

### DIFF
--- a/src/app/Classes/achievement.spec.ts
+++ b/src/app/Classes/achievement.spec.ts
@@ -2,6 +2,7 @@ import { Achievement } from './achievement';
 
 describe('Achievement', () => {
   it('should create an instance', () => {
-    expect(new Achievement()).toBeTruthy();
+    const ach = new Achievement('Ach', 'desc', 1, 10, 'Other');
+    expect(ach).toBeTruthy();
   });
 });

--- a/src/app/Classes/card.spec.ts
+++ b/src/app/Classes/card.spec.ts
@@ -1,7 +1,8 @@
-import { Card } from './card';
+import { Card, CardType, BonusType } from './card';
 
 describe('Card', () => {
   it('should create an instance', () => {
-    expect(new Card()).toBeTruthy();
+    const card = new Card('Test Card', 'Common' as CardType, 'PointsAmount' as BonusType, 1);
+    expect(card).toBeTruthy();
   });
 });

--- a/src/app/Classes/challenge.spec.ts
+++ b/src/app/Classes/challenge.spec.ts
@@ -1,7 +1,15 @@
-import { Challenge } from './challenge';
+import { Challenge, ChallengeType } from './challenge';
 
 describe('Challenge', () => {
   it('should create an instance', () => {
-    expect(new Challenge()).toBeTruthy();
+    const chal = new Challenge(
+      'Accuracy' as ChallengeType,
+      'Test challenge',
+      'Reward',
+      60,
+      10,
+      5
+    );
+    expect(chal).toBeTruthy();
   });
 });

--- a/src/app/Classes/game.spec.ts
+++ b/src/app/Classes/game.spec.ts
@@ -2,6 +2,7 @@ import { Game } from './game';
 
 describe('Game', () => {
   it('should create an instance', () => {
-    expect(new Game()).toBeTruthy();
+    const game = new Game(0, 'Active');
+    expect(game).toBeTruthy();
   });
 });

--- a/src/app/Classes/generator.spec.ts
+++ b/src/app/Classes/generator.spec.ts
@@ -2,6 +2,7 @@ import { Generator } from './generator';
 
 describe('Generator', () => {
   it('should create an instance', () => {
-    expect(new Generator()).toBeTruthy();
+    const gen = new Generator('Gen', 10, 1);
+    expect(gen).toBeTruthy();
   });
 });

--- a/src/app/Classes/mastery.spec.ts
+++ b/src/app/Classes/mastery.spec.ts
@@ -2,6 +2,7 @@ import { Mastery } from './mastery';
 
 describe('Mastery', () => {
   it('should create an instance', () => {
-    expect(new Mastery()).toBeTruthy();
+    const mas = new Mastery('Alpha', ['a']);
+    expect(mas).toBeTruthy();
   });
 });

--- a/src/app/Classes/pack.spec.ts
+++ b/src/app/Classes/pack.spec.ts
@@ -2,6 +2,7 @@ import { Pack } from './pack';
 
 describe('Pack', () => {
   it('should create an instance', () => {
-    expect(new Pack()).toBeTruthy();
+    const pack = new Pack('Starter', 10);
+    expect(pack).toBeTruthy();
   });
 });

--- a/src/app/Classes/upgrade.spec.ts
+++ b/src/app/Classes/upgrade.spec.ts
@@ -2,6 +2,7 @@ import { Upgrade } from './upgrade';
 
 describe('Upgrade', () => {
   it('should create an instance', () => {
-    expect(new Upgrade()).toBeTruthy();
+    const upg = new Upgrade('Test', 'desc', 1, 'FirstUpgradePoints', 'Starter');
+    expect(upg).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- update spec files to use minimal constructor arguments

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b383b1c8832a966c0ce53a85e22d