### PR TITLE
Add grouping capability to achievements

### DIFF
--- a/src/app/Classes/achievement.ts
+++ b/src/app/Classes/achievement.ts
@@ -6,18 +6,21 @@ export class Achievement {
   description: string;
   target: number;
   property: keyof Game | 'Other';
+  group?: string;
 
   constructor(
     achievementName: string,
     achievementDesc: string,
     achievementNumber: number,
     target: number,
-    property: keyof Game | 'Other'
+    property: keyof Game | 'Other',
+    group?: string
   ) {
     this.id = achievementNumber;
     this.name = achievementName;
     this.description = achievementDesc;
     this.property = property;
     this.target = target;
+    this.group = group;
   }
 }

--- a/src/app/Services/achievement.service.ts
+++ b/src/app/Services/achievement.service.ts
@@ -556,9 +556,42 @@ export class AchievementService {
       return acc;
     }, {} as { [group: string]: Achievement[] });
   }
-  
+
 
   createAchievement(achievement: Achievement) {
+    if (!achievement.group) {
+      switch (achievement.property) {
+        case 'wordsAmount':
+          achievement.group = 'Words Amount';
+          break;
+        case 'points':
+          achievement.group = 'Points';
+          break;
+        case 'passivePoints':
+          achievement.group = 'Passive Points';
+          break;
+        case 'cardsAmount':
+          achievement.group = 'Cards Amount';
+          break;
+        case 'mergeCount':
+          achievement.group = 'Merge Count';
+          break;
+        case 'challengesAmount':
+          achievement.group = 'Challenges Amount';
+          break;
+        case 'prestigeCount':
+          achievement.group = 'Prestige Count';
+          break;
+        case 'prestigePoints':
+          achievement.group = 'Prestige Points';
+          break;
+        case 'wordCounterPerfection':
+          achievement.group = 'Word Counter Perfection';
+          break;
+        default:
+          achievement.group = 'Other';
+      }
+    }
     this.achievements.push(achievement);
   }
 

--- a/src/app/Services/challenge.service.spec.ts
+++ b/src/app/Services/challenge.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
-import { ChallengeService } from './challenge.service';
+import { ChallengesService } from './challenge.service';
 
-describe('ChallengeService', () => {
-  let service: ChallengeService;
+describe('ChallengesService', () => {
+  let service: ChallengesService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(ChallengeService);
+    service = TestBed.inject(ChallengesService);
   });
 
   it('should be created', () => {


### PR DESCRIPTION
## Summary
- extend `Achievement` model with optional `group` property
- set achievement group automatically in `AchievementService`
- fix test setup for `ChallengesService`

## Testing
- `npx ng test --browsers=ChromeHeadless --watch=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6843c1d00c68832aade884e2efcd54a7