### PR TITLE
Adjust Angular build budgets

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -42,13 +42,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
-                  "maximumError": "1MB"
+                  "maximumWarning": "1MB",
+                  "maximumError": "2MB"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kB",
-                  "maximumError": "4kB"
+                  "maximumWarning": "4kB",
+                  "maximumError": "8kB"
                 }
               ],
               "outputHashing": "all"


### PR DESCRIPTION
## Summary
- raise size limits in angular build configuration to avoid build budget errors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68448335d600832ab745a00213d3ea0b