### PR TITLE
Fix letter count test expectation

### DIFF
--- a/src/app/Services/active.service.spec.ts
+++ b/src/app/Services/active.service.spec.ts
@@ -27,7 +27,8 @@ describe('ActiveService', () => {
 
   it('counts different letters ignoring case', () => {
     expect(service.getDifferentLetters('abc')).toBe(3);
-    expect(service.getDifferentLetters('Letter')).toBe(5);
+    // "Letter" has only four distinct letters when case is ignored
+    expect(service.getDifferentLetters('Letter')).toBe(4);
     expect(service.getDifferentLetters('AaAa')).toBe(1);
   });
 

--- a/src/app/Services/active.service.spec.ts
+++ b/src/app/Services/active.service.spec.ts
@@ -27,7 +27,6 @@ describe('ActiveService', () => {
 
   it('counts different letters ignoring case', () => {
     expect(service.getDifferentLetters('abc')).toBe(3);
-    // "Letter" has only four distinct letters when case is ignored
     expect(service.getDifferentLetters('Letter')).toBe(4);
     expect(service.getDifferentLetters('AaAa')).toBe(1);
   });


### PR DESCRIPTION
## Summary
- correct letter count test expectation for `getDifferentLetters`

## Testing
- `npx ng test --watch=false` *(fails: requires chromium snap)*

------
https://chatgpt.com/codex/tasks/task_e_684489d31b80832ab353cfa90d60f4dc