### PR TITLE
Move card definitions to JSON

### DIFF
--- a/public/cards.json
+++ b/public/cards.json
@@ -1,0 +1,428 @@
+[
+  {
+    "name": "Percentage Points Booster",
+    "type": "Common",
+    "bonusType": "PointsPercentage",
+    "id": 1
+  },
+  {
+    "name": "Nominal Points Booster",
+    "type": "Common",
+    "bonusType": "PointsAmount",
+    "id": 2
+  },
+  {
+    "name": "Percentage Passive Points Improver",
+    "type": "Common",
+    "bonusType": "PassivePointsPercentage",
+    "id": 3
+  },
+  {
+    "name": "Nominal Passive Points Improver",
+    "type": "Common",
+    "bonusType": "PassivePointsAmount",
+    "id": 4
+  },
+  {
+    "name": "Percentage Points Augmentor",
+    "type": "Uncommon",
+    "bonusType": "PointsPercentage",
+    "id": 5
+  },
+  {
+    "name": "Nominal Points Augmentor",
+    "type": "Uncommon",
+    "bonusType": "PointsAmount",
+    "id": 6
+  },
+  {
+    "name": "Percentage Passive Points Infuser",
+    "type": "Uncommon",
+    "bonusType": "PassivePointsPercentage",
+    "id": 7
+  },
+  {
+    "name": "Nominal Passive Points Infuser",
+    "type": "Uncommon",
+    "bonusType": "PassivePointsAmount",
+    "id": 8
+  },
+  {
+    "name": "Passive Points Accelerator",
+    "type": "Uncommon",
+    "bonusType": "PassivePointsSpeed",
+    "id": 9
+  },
+  {
+    "name": "Word Length Extender",
+    "type": "Uncommon",
+    "bonusType": "PassivePointsLength",
+    "id": 10
+  },
+  {
+    "name": "Income Impairer",
+    "type": "Broken",
+    "bonusType": "PointsPercentage",
+    "id": 24
+  },
+  {
+    "name": "Detrimental Debt",
+    "type": "Broken",
+    "bonusType": "PointsAmount",
+    "id": 25
+  },
+  {
+    "name": "Debilitating Discount",
+    "type": "Broken",
+    "bonusType": "PassivePointsPercentage",
+    "id": 26
+  },
+  {
+    "name": "Shrinking Stash",
+    "type": "Broken",
+    "bonusType": "PassivePointsAmount",
+    "id": 27
+  },
+  {
+    "name": "Lethargic Generator",
+    "type": "Broken",
+    "bonusType": "PassivePointsSpeed",
+    "id": 28
+  },
+  {
+    "name": "Diminished Diction",
+    "type": "Broken",
+    "bonusType": "PassivePointsLength",
+    "id": 29
+  },
+  {
+    "name": "Percentage Points Magnifier",
+    "type": "Rare",
+    "bonusType": "PointsPercentage",
+    "id": 11
+  },
+  {
+    "name": "All Lowercase",
+    "type": "Legendary",
+    "bonusType": "Lowercase",
+    "id": 12
+  },
+  {
+    "name": "Nominal Points Magnifier",
+    "type": "Rare",
+    "bonusType": "PointsAmount",
+    "id": 13
+  },
+  {
+    "name": "Percentage Passive Points Energizer",
+    "type": "Rare",
+    "bonusType": "PassivePointsPercentage",
+    "id": 14
+  },
+  {
+    "name": "Nominal Passive Points Energizer",
+    "type": "Rare",
+    "bonusType": "PassivePointsAmount",
+    "id": 15
+  },
+  {
+    "name": "Passive Points Turbocharger",
+    "type": "Rare",
+    "bonusType": "PassivePointsSpeed",
+    "id": 16
+  },
+  {
+    "name": "Word Length Expander",
+    "type": "Rare",
+    "bonusType": "PassivePointsLength",
+    "id": 17
+  },
+  {
+    "name": "Percentage Points Empowerer",
+    "type": "Epic",
+    "bonusType": "PointsPercentage",
+    "id": 18
+  },
+  {
+    "name": "Nominal Points Empowerer",
+    "type": "Epic",
+    "bonusType": "PointsAmount",
+    "id": 19
+  },
+  {
+    "name": "Percentage Passive Points Dynamo",
+    "type": "Epic",
+    "bonusType": "PassivePointsPercentage",
+    "id": 20
+  },
+  {
+    "name": "Nominal Passive Points Dynamo",
+    "type": "Epic",
+    "bonusType": "PassivePointsAmount",
+    "id": 21
+  },
+  {
+    "name": "Passive Points Booster",
+    "type": "Epic",
+    "bonusType": "PassivePointsSpeed",
+    "id": 22
+  },
+  {
+    "name": "Word Length Enhancer",
+    "type": "Epic",
+    "bonusType": "PassivePointsLength",
+    "id": 23
+  },
+  {
+    "name": "Significant Surge",
+    "type": "Legendary",
+    "bonusType": "PointsPercentage",
+    "id": 30
+  },
+  {
+    "name": "Masterful Magnification",
+    "type": "Legendary",
+    "bonusType": "PointsAmount",
+    "id": 31
+  },
+  {
+    "name": "Measured Momentum",
+    "type": "Legendary",
+    "bonusType": "PassivePointsPercentage",
+    "id": 32
+  },
+  {
+    "name": "Incremental Impact",
+    "type": "Legendary",
+    "bonusType": "PassivePointsAmount",
+    "id": 33
+  },
+  {
+    "name": "Speedy Scripting",
+    "type": "Legendary",
+    "bonusType": "PassivePointsSpeed",
+    "id": 34
+  },
+  {
+    "name": "Longevity Linguistics",
+    "type": "Legendary",
+    "bonusType": "PassivePointsLength",
+    "id": 35
+  },
+  {
+    "name": "Pronounced Percentage",
+    "type": "Mythical",
+    "bonusType": "PointsPercentage",
+    "id": 36
+  },
+  {
+    "name": "Grandiose Gain",
+    "type": "Mythical",
+    "bonusType": "PointsAmount",
+    "id": 37
+  },
+  {
+    "name": "Exponential Enhancement",
+    "type": "Mythical",
+    "bonusType": "PassivePointsPercentage",
+    "id": 38
+  },
+  {
+    "name": "Steady Stream",
+    "type": "Mythical",
+    "bonusType": "PassivePointsAmount",
+    "id": 39
+  },
+  {
+    "name": "Hustle Harmony",
+    "type": "Mythical",
+    "bonusType": "PassivePointsSpeed",
+    "id": 40
+  },
+  {
+    "name": "Word Length Enhancer",
+    "type": "Mythical",
+    "bonusType": "PassivePointsLength",
+    "id": 41
+  },
+  {
+    "name": "Elevated Expansion",
+    "type": "Celestial",
+    "bonusType": "PointsPercentage",
+    "id": 42
+  },
+  {
+    "name": "Illustrious Increase",
+    "type": "Celestial",
+    "bonusType": "PointsAmount",
+    "id": 43
+  },
+  {
+    "name": "Amplified Ascendance",
+    "type": "Celestial",
+    "bonusType": "PassivePointsPercentage",
+    "id": 44
+  },
+  {
+    "name": "Amplified Accumulation",
+    "type": "Celestial",
+    "bonusType": "PassivePointsAmount",
+    "id": 45
+  },
+  {
+    "name": "Velocity Versification",
+    "type": "Celestial",
+    "bonusType": "PassivePointsSpeed",
+    "id": 46
+  },
+  {
+    "name": "Extended Enunciation",
+    "type": "Celestial",
+    "bonusType": "PassivePointsLength",
+    "id": 47
+  },
+  {
+    "name": "Substantial Spike",
+    "type": "Divine",
+    "bonusType": "PointsPercentage",
+    "id": 48
+  },
+  {
+    "name": "Prodigious Profit",
+    "type": "Divine",
+    "bonusType": "PointsAmount",
+    "id": 49
+  },
+  {
+    "name": "Magnitude Multiplicity",
+    "type": "Divine",
+    "bonusType": "PassivePointsPercentage",
+    "id": 50
+  },
+  {
+    "name": "Significant Surplus",
+    "type": "Divine",
+    "bonusType": "PassivePointsAmount",
+    "id": 51
+  },
+  {
+    "name": "Supersonic Script",
+    "type": "Divine",
+    "bonusType": "PassivePointsSpeed",
+    "id": 52
+  },
+  {
+    "name": "Enduring Expression",
+    "type": "Divine",
+    "bonusType": "PassivePointsLength",
+    "id": 53
+  },
+  {
+    "name": "Momentous Multiplicity",
+    "type": "Ultimate",
+    "bonusType": "PointsPercentage",
+    "id": 54
+  },
+  {
+    "name": "Monumental Multiplication",
+    "type": "Ultimate",
+    "bonusType": "PointsAmount",
+    "id": 55
+  },
+  {
+    "name": "Grandiose Gargantua",
+    "type": "Ultimate",
+    "bonusType": "PassivePointsPercentage",
+    "id": 56
+  },
+  {
+    "name": "Elevated Endowment",
+    "type": "Ultimate",
+    "bonusType": "PassivePointsAmount",
+    "id": 57
+  },
+  {
+    "name": "Majestic Manuscript",
+    "type": "Ultimate",
+    "bonusType": "PassivePointsSpeed",
+    "id": 58
+  },
+  {
+    "name": "Celestial Composition",
+    "type": "Ultimate",
+    "bonusType": "PassivePointsLength",
+    "id": 59
+  },
+  {
+    "name": "Mythic Magnitude",
+    "type": "Infinite",
+    "bonusType": "PointsPercentage",
+    "id": 60
+  },
+  {
+    "name": "Legendary Lucre",
+    "type": "Infinite",
+    "bonusType": "PointsAmount",
+    "id": 61
+  },
+  {
+    "name": "Ultimate Uplift",
+    "type": "Infinite",
+    "bonusType": "PassivePointsPercentage",
+    "id": 62
+  },
+  {
+    "name": "Paramount Proliferation",
+    "type": "Infinite",
+    "bonusType": "PassivePointsAmount",
+    "id": 63
+  },
+  {
+    "name": "Grandiloquent Gyrator",
+    "type": "Infinite",
+    "bonusType": "PassivePointsSpeed",
+    "id": 64
+  },
+  {
+    "name": "Majestic Manifestation",
+    "type": "Infinite",
+    "bonusType": "PassivePointsLength",
+    "id": 65
+  },
+  {
+    "name": "Supreme Surplus",
+    "type": "Omnipotent",
+    "bonusType": "PointsPercentage",
+    "id": 66
+  },
+  {
+    "name": "Transcendent Treasury",
+    "type": "Omnipotent",
+    "bonusType": "PointsAmount",
+    "id": 67
+  },
+  {
+    "name": "Celestial Sovereignty",
+    "type": "Omnipotent",
+    "bonusType": "PassivePointsPercentage",
+    "id": 68
+  },
+  {
+    "name": "Ultimate Ubiquity",
+    "type": "Omnipotent",
+    "bonusType": "PassivePointsAmount",
+    "id": 69
+  },
+  {
+    "name": "Celestial Celerity",
+    "type": "Omnipotent",
+    "bonusType": "PassivePointsSpeed",
+    "id": 70
+  },
+  {
+    "name": "Supreme Syllabication",
+    "type": "Omnipotent",
+    "bonusType": "PassivePointsLength",
+    "id": 71
+  }
+]

--- a/src/app/Services/card.service.ts
+++ b/src/app/Services/card.service.ts
@@ -1,5 +1,5 @@
-import { inject, Injectable, OnInit } from '@angular/core';
-import { Card, CardType } from '../Classes/card';
+import { inject, Injectable } from '@angular/core';
+import { Card, CardType, BonusType } from '../Classes/card';
 import { Pack, PackTier } from '../Classes/pack';
 import { GameUtils } from '../Utils/gameUtils';
 import { GameService } from './game.service';
@@ -15,289 +15,15 @@ export class CardService {
   achievementService = inject(AchievementService);
   cards: Card[] = [];
   constructor() {
-    this.createCard(
-      new Card('Percentage Points Booster', 'Common', 'PointsPercentage', 1)
-    );
-    this.createCard(
-      new Card('Nominal Points Booster', 'Common', 'PointsAmount', 2)
-    );
-    this.createCard(
-      new Card(
-        'Percentage Passive Points Improver',
-        'Common',
-        'PassivePointsPercentage',
-        3
-      )
-    );
-    this.createCard(
-      new Card(
-        'Nominal Passive Points Improver',
-        'Common',
-        'PassivePointsAmount',
-        4
-      )
-    );
+    this.loadCards();
+  }
 
-    this.createCard(
-      new Card('Percentage Points Augmentor', 'Uncommon', 'PointsPercentage', 5)
-    );
-    this.createCard(
-      new Card('Nominal Points Augmentor', 'Uncommon', 'PointsAmount', 6)
-    );
-    this.createCard(
-      new Card(
-        'Percentage Passive Points Infuser',
-        'Uncommon',
-        'PassivePointsPercentage',
-        7
-      )
-    );
-    this.createCard(
-      new Card(
-        'Nominal Passive Points Infuser',
-        'Uncommon',
-        'PassivePointsAmount',
-        8
-      )
-    );
-    this.createCard(
-      new Card(
-        'Passive Points Accelerator',
-        'Uncommon',
-        'PassivePointsSpeed',
-        9
-      )
-    );
-    this.createCard(
-      new Card('Word Length Extender', 'Uncommon', 'PassivePointsLength', 10)
-    );
-
-    this.createCard(
-      new Card('Income Impairer', 'Broken', 'PointsPercentage', 24)
-    );
-    this.createCard(new Card('Detrimental Debt', 'Broken', 'PointsAmount', 25));
-    this.createCard(
-      new Card('Debilitating Discount', 'Broken', 'PassivePointsPercentage', 26)
-    );
-    this.createCard(
-      new Card('Shrinking Stash', 'Broken', 'PassivePointsAmount', 27)
-    );
-    this.createCard(
-      new Card('Lethargic Generator', 'Broken', 'PassivePointsSpeed', 28)
-    );
-    this.createCard(
-      new Card('Diminished Diction', 'Broken', 'PassivePointsLength', 29)
-    );
-
-    this.createCard(
-      new Card('Percentage Points Magnifier', 'Rare', 'PointsPercentage', 11)
-    );
-    this.createCard(new Card('All Lowercase', 'Legendary', 'Lowercase', 12));
-    this.createCard(
-      new Card('Nominal Points Magnifier', 'Rare', 'PointsAmount', 13)
-    );
-    this.createCard(
-      new Card(
-        'Percentage Passive Points Energizer',
-        'Rare',
-        'PassivePointsPercentage',
-        14
-      )
-    );
-    this.createCard(
-      new Card(
-        'Nominal Passive Points Energizer',
-        'Rare',
-        'PassivePointsAmount',
-        15
-      )
-    );
-    this.createCard(
-      new Card('Passive Points Turbocharger', 'Rare', 'PassivePointsSpeed', 16)
-    );
-    this.createCard(
-      new Card('Word Length Expander', 'Rare', 'PassivePointsLength', 17)
-    );
-
-    this.createCard(
-      new Card('Percentage Points Empowerer', 'Epic', 'PointsPercentage', 18)
-    );
-    this.createCard(
-      new Card('Nominal Points Empowerer', 'Epic', 'PointsAmount', 19)
-    );
-    this.createCard(
-      new Card(
-        'Percentage Passive Points Dynamo',
-        'Epic',
-        'PassivePointsPercentage',
-        20
-      )
-    );
-    this.createCard(
-      new Card(
-        'Nominal Passive Points Dynamo',
-        'Epic',
-        'PassivePointsAmount',
-        21
-      )
-    );
-    this.createCard(
-      new Card('Passive Points Booster', 'Epic', 'PassivePointsSpeed', 22)
-    );
-    this.createCard(
-      new Card('Word Length Enhancer', 'Epic', 'PassivePointsLength', 23)
-    );
-
-    this.createCard(
-      new Card('Significant Surge', 'Legendary', 'PointsPercentage', 30)
-    );
-    this.createCard(
-      new Card('Masterful Magnification', 'Legendary', 'PointsAmount', 31)
-    );
-    this.createCard(
-      new Card('Measured Momentum', 'Legendary', 'PassivePointsPercentage', 32)
-    );
-    this.createCard(
-      new Card('Incremental Impact', 'Legendary', 'PassivePointsAmount', 33)
-    );
-    this.createCard(
-      new Card('Speedy Scripting', 'Legendary', 'PassivePointsSpeed', 34)
-    );
-    this.createCard(
-      new Card('Longevity Linguistics', 'Legendary', 'PassivePointsLength', 35)
-    );
-
-    this.createCard(
-      new Card('Pronounced Percentage', 'Mythical', 'PointsPercentage', 36)
-    );
-    this.createCard(new Card('Grandiose Gain', 'Mythical', 'PointsAmount', 37));
-    this.createCard(
-      new Card(
-        'Exponential Enhancement',
-        'Mythical',
-        'PassivePointsPercentage',
-        38
-      )
-    );
-    this.createCard(
-      new Card('Steady Stream', 'Mythical', 'PassivePointsAmount', 39)
-    );
-    this.createCard(
-      new Card('Hustle Harmony', 'Mythical', 'PassivePointsSpeed', 40)
-    );
-    this.createCard(
-      new Card('Word Length Enhancer', 'Mythical', 'PassivePointsLength', 41)
-    );
-
-    this.createCard(
-      new Card('Elevated Expansion', 'Celestial', 'PointsPercentage', 42)
-    );
-    this.createCard(
-      new Card('Illustrious Increase', 'Celestial', 'PointsAmount', 43)
-    );
-    this.createCard(
-      new Card(
-        'Amplified Ascendance',
-        'Celestial',
-        'PassivePointsPercentage',
-        44
-      )
-    );
-    this.createCard(
-      new Card('Amplified Accumulation', 'Celestial', 'PassivePointsAmount', 45)
-    );
-    this.createCard(
-      new Card('Velocity Versification', 'Celestial', 'PassivePointsSpeed', 46)
-    );
-    this.createCard(
-      new Card('Extended Enunciation', 'Celestial', 'PassivePointsLength', 47)
-    );
-
-    this.createCard(
-      new Card('Substantial Spike', 'Divine', 'PointsPercentage', 48)
-    );
-    this.createCard(
-      new Card('Prodigious Profit', 'Divine', 'PointsAmount', 49)
-    );
-    this.createCard(
-      new Card(
-        'Magnitude Multiplicity',
-        'Divine',
-        'PassivePointsPercentage',
-        50
-      )
-    );
-    this.createCard(
-      new Card('Significant Surplus', 'Divine', 'PassivePointsAmount', 51)
-    );
-    this.createCard(
-      new Card('Supersonic Script', 'Divine', 'PassivePointsSpeed', 52)
-    );
-    this.createCard(
-      new Card('Enduring Expression', 'Divine', 'PassivePointsLength', 53)
-    );
-
-    this.createCard(
-      new Card('Momentous Multiplicity', 'Ultimate', 'PointsPercentage', 54)
-    );
-    this.createCard(
-      new Card('Monumental Multiplication', 'Ultimate', 'PointsAmount', 55)
-    );
-    this.createCard(
-      new Card('Grandiose Gargantua', 'Ultimate', 'PassivePointsPercentage', 56)
-    );
-    this.createCard(
-      new Card('Elevated Endowment', 'Ultimate', 'PassivePointsAmount', 57)
-    );
-    this.createCard(
-      new Card('Majestic Manuscript', 'Ultimate', 'PassivePointsSpeed', 58)
-    );
-    this.createCard(
-      new Card('Celestial Composition', 'Ultimate', 'PassivePointsLength', 59)
-    );
-
-    this.createCard(
-      new Card('Mythic Magnitude', 'Infinite', 'PointsPercentage', 60)
-    );
-    this.createCard(
-      new Card('Legendary Lucre', 'Infinite', 'PointsAmount', 61)
-    );
-    this.createCard(
-      new Card('Ultimate Uplift', 'Infinite', 'PassivePointsPercentage', 62)
-    );
-    this.createCard(
-      new Card('Paramount Proliferation', 'Infinite', 'PassivePointsAmount', 63)
-    );
-    this.createCard(
-      new Card('Grandiloquent Gyrator', 'Infinite', 'PassivePointsSpeed', 64)
-    );
-    this.createCard(
-      new Card('Majestic Manifestation', 'Infinite', 'PassivePointsLength', 65)
-    );
-
-    this.createCard(
-      new Card('Supreme Surplus', 'Omnipotent', 'PointsPercentage', 66)
-    );
-    this.createCard(
-      new Card('Transcendent Treasury', 'Omnipotent', 'PointsAmount', 67)
-    );
-    this.createCard(
-      new Card(
-        'Celestial Sovereignty',
-        'Omnipotent',
-        'PassivePointsPercentage',
-        68
-      )
-    );
-    this.createCard(
-      new Card('Ultimate Ubiquity', 'Omnipotent', 'PassivePointsAmount', 69)
-    );
-    this.createCard(
-      new Card('Celestial Celerity', 'Omnipotent', 'PassivePointsSpeed', 70)
-    );
-    this.createCard(
-      new Card('Supreme Syllabication', 'Omnipotent', 'PassivePointsLength', 71)
-    );
+  private async loadCards() {
+    const response = await fetch('/cards.json');
+    const list: CardJson[] = await response.json();
+    for (const c of list) {
+      this.createCard(new Card(c.name, c.type, c.bonusType, c.id));
+    }
   }
 
   createCard(card: Card) {
@@ -569,4 +295,11 @@ export class CardService {
         100;
     return [pointsPercentageBonus, 'x Sum of PointsPercentage Card'];
   }
+}
+
+interface CardJson {
+  name: string;
+  type: CardType;
+  bonusType: BonusType;
+  id: number;
 }


### PR DESCRIPTION
## Summary
- extract card data into `public/cards.json`
- load cards asynchronously from JSON in `CardService`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684613f81dc0832a9f53ea3a85a44fc3