### PR TITLE
Add vertical prestige era meter

### DIFF
--- a/src/app/Classes/era.spec.ts
+++ b/src/app/Classes/era.spec.ts
@@ -2,6 +2,7 @@ import { Era } from './era';
 
 describe('Era', () => {
   it('should create an instance', () => {
-    expect(new Era()).toBeTruthy();
+    const era = new Era('Test Era', 1, 'desc', 1);
+    expect(era).toBeTruthy();
   });
 });

--- a/src/app/Classes/mastery.spec.ts
+++ b/src/app/Classes/mastery.spec.ts
@@ -2,7 +2,7 @@ import { Mastery } from './mastery';
 
 describe('Mastery', () => {
   it('should create an instance', () => {
-    const mas = new Mastery('Alpha', ['a']);
+    const mas = new Mastery('Alpha', ['a'], 1);
     expect(mas).toBeTruthy();
   });
 });

--- a/src/app/Menus/prestige-menu/prestige-menu.component.html
+++ b/src/app/Menus/prestige-menu/prestige-menu.component.html
@@ -5,6 +5,12 @@
     <button class="prestigeButton" (click)="fadeOutBody()">Prestige!</button>
   </div>
   <div class="era-container">
+    <div class="progress-fill" [style.height.%]="prestigeProgress()"></div>
+    @for (marker of eraMarkers(); track marker.name) {
+      <div class="era-marker" [style.bottom.%]="marker.position">
+        <span class="era-label">{{ marker.name }}</span>
+      </div>
+    }
   </div>
 </section>
  

--- a/src/app/Menus/prestige-menu/prestige-menu.component.scss
+++ b/src/app/Menus/prestige-menu/prestige-menu.component.scss
@@ -17,12 +17,50 @@
     font-size: var(--big-custom-text);
   }
   
-  .prestigeButton {
+.prestigeButton {
     animation: background-pan 2s linear infinite;
     background: linear-gradient(to right, var(--black-900), var(--golden), var(--black-900));
     background-size: 200%;
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
-    white-space: nowrap; 
+    white-space: nowrap;
   }
+
+.era-container {
+  position: relative;
+  width: 1.5rem;
+  height: 12rem;
+  margin: 2rem auto;
+  border: 0.2rem solid var(--primary-400);
+  border-radius: 0.75rem;
+  background-color: var(--primary-900);
+}
+
+.progress-fill {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 0%;
+  background-color: var(--primary-300);
+  border-radius: 0 0 0.75rem 0.75rem;
+  transition: height 300ms ease;
+}
+
+.era-marker {
+  bottom: 0;
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 0.2rem;
+  background-color: var(--accent-300);
+  transform: translateY(50%);
+}
+
+.era-label {
+  position: absolute;
+  left: 110%;
+  transform: translateY(50%);
+  font-size: var(--xsmall-custom-text);
+  white-space: nowrap;
+}

--- a/src/app/Menus/prestige-menu/prestige-menu.component.ts
+++ b/src/app/Menus/prestige-menu/prestige-menu.component.ts
@@ -19,6 +19,27 @@ export class PrestigeMenuComponent {
     return Math.round(Math.pow(this.gameService.game().points, exp));
   });
 
+  prestigeProgress = computed(() => {
+    const points = this.gameService.game().prestigePoints;
+    const eras = this.prestigeService.eras;
+    if (eras.length === 0) return 0;
+    const maxValue = Math.log10(Math.max(eras[eras.length - 1].numberToReach, 1));
+    if (maxValue === 0) return 100;
+    const value = Math.log10(Math.max(points, 1));
+    return Math.min((value / maxValue) * 100, 100);
+  });
+
+  eraMarkers = computed(() => {
+    const eras = this.prestigeService.eras;
+    if (eras.length === 0) return [] as { name: string; position: number }[];
+    const maxValue = Math.log10(Math.max(eras[eras.length - 1].numberToReach, 1));
+    return eras.map(era => {
+      const value = era.numberToReach > 0 ? Math.log10(era.numberToReach) : 0;
+      const position = maxValue === 0 ? 0 : (value / maxValue) * 100;
+      return { name: era.name, position };
+    });
+  });
+
   constructor(
     private renderer: Renderer2
   ) {


### PR DESCRIPTION
## Summary
- orient prestige era meter vertically
- adjust marker positioning
- fix era and mastery spec creation errors

## Testing
- `./setup.sh`
- `export CHROME_BIN=$(which chromium-browser)`
- `npm test --silent` *(fails: cannot start Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68523978c174832a95fee09a9f511dcd