### PR TITLE
Highlight reached eras

### DIFF
--- a/src/app/Menus/prestige-menu/prestige-menu.component.html
+++ b/src/app/Menus/prestige-menu/prestige-menu.component.html
@@ -8,7 +8,7 @@
     <div class="progress-fill" [style.height.%]="prestigeProgress()"></div>
     @for (marker of eraMarkers(); track marker.name) {
       <div class="era-marker" [style.bottom.%]="marker.position">
-        <span class="era-label">{{ marker.name }}</span>
+        <span class="era-label" [class.reached]="marker.reached">{{ marker.name }}</span>
       </div>
     }
   </div>

--- a/src/app/Menus/prestige-menu/prestige-menu.component.scss
+++ b/src/app/Menus/prestige-menu/prestige-menu.component.scss
@@ -64,3 +64,7 @@
   font-size: var(--xsmall-custom-text);
   white-space: nowrap;
 }
+
+.era-label.reached {
+  color: var(--green);
+}

--- a/src/app/Menus/prestige-menu/prestige-menu.component.ts
+++ b/src/app/Menus/prestige-menu/prestige-menu.component.ts
@@ -31,12 +31,14 @@ export class PrestigeMenuComponent {
 
   eraMarkers = computed(() => {
     const eras = this.prestigeService.eras;
-    if (eras.length === 0) return [] as { name: string; position: number }[];
+    if (eras.length === 0) return [] as { name: string; position: number; reached: boolean }[];
     const maxValue = Math.log10(Math.max(eras[eras.length - 1].numberToReach, 1));
+    const reachedEras = this.gameService.game().prestigeEras.map(e => e.name);
     return eras.map(era => {
       const value = era.numberToReach > 0 ? Math.log10(era.numberToReach) : 0;
       const position = maxValue === 0 ? 0 : (value / maxValue) * 100;
-      return { name: era.name, position };
+      const reached = reachedEras.includes(era.name);
+      return { name: era.name, position, reached };
     });
   });
 


### PR DESCRIPTION
## Summary
- highlight reached eras in the prestige meter
- show green label for reached eras

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: cannot start ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_685244bd9e00832a9f08a3bb57c13ab2