### PR TITLE
Restrict upgrade tree zoom and pan

### DIFF
--- a/src/app/Menus/upgrades-menu/upgrades-menu.component.ts
+++ b/src/app/Menus/upgrades-menu/upgrades-menu.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { UpgradeService } from '../../Services/upgrade.service';
 import { eIdUpgrade, Upgrade } from '../../Classes/upgrade';
 import { GameService } from '../../Services/game.service';
@@ -14,7 +14,7 @@ import { TabsModule } from  'primeng/tabs'
   standalone: true,
   imports: [CommonModule, ExponentialNumberPipe, MatCardModule, TabsModule],
 })
-export class UpgradesMenuComponent {
+export class UpgradesMenuComponent implements OnInit {
   upgradeService = inject(UpgradeService);
   gameService = inject(GameService)
   upgrades = this.upgradeService.starterUpgrades.concat(
@@ -28,6 +28,10 @@ export class UpgradesMenuComponent {
   );
 
   selectedUpgrade: Upgrade | null = null;
+
+  ngOnInit() {
+    this.updateViewBox();
+  }
 
   selectUpgrade(upgrade: Upgrade) {
     this.selectedUpgrade = upgrade;
@@ -79,8 +83,19 @@ export class UpgradesMenuComponent {
   // ViewBox control
   viewBox = '-100 -150 600 600';
   private panStart: { x: number; y: number } | null = null;
-  private offset = { x: -300, y: -300 };
+  // Coordinates of the first upgrade in upgrades.json
+  private readonly ROOT_POS = { x: 150, y: 100 };
+  private offset = { x: this.ROOT_POS.x - 300, y: this.ROOT_POS.y - 300 };
   private scale = 1;
+
+  private readonly MIN_SCALE = 0.5;
+  private readonly MAX_SCALE = 2.5;
+  private readonly BOUNDS = {
+    minX: -250,
+    maxX: 2100,
+    minY: -250,
+    maxY: 1400,
+  };
 
   startPan(event: MouseEvent) {
     this.panStart = { x: event.clientX, y: event.clientY };
@@ -110,12 +125,17 @@ export class UpgradesMenuComponent {
     } else {
       this.scale /= zoomFactor;
     }
+    this.scale = Math.min(Math.max(this.scale, this.MIN_SCALE), this.MAX_SCALE);
     this.updateViewBox();
   }
 
   updateViewBox() {
     const width = 600 / this.scale;
     const height = 600 / this.scale;
+    const maxX = this.BOUNDS.maxX - width;
+    const maxY = this.BOUNDS.maxY - height;
+    this.offset.x = Math.min(Math.max(this.offset.x, this.BOUNDS.minX), maxX);
+    this.offset.y = Math.min(Math.max(this.offset.y, this.BOUNDS.minY), maxY);
     this.viewBox = `${this.offset.x} ${this.offset.y} ${width} ${height}`;
   }
 


### PR DESCRIPTION
## Summary
- center upgrade tree on first upgrade
- clamp zooming and panning to fixed bounds
- limit scale between 0.5x and 2.5x

## Testing
- `./setup.sh` *(passed)*
- `npm test` *(failed: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68595e8bfdc8832a8da9b0c2a92acea9