### PR TITLE
Dynamic bounds for each upgrade tree

### DIFF
--- a/src/app/Menus/upgrades-menu/upgrades-menu.component.html
+++ b/src/app/Menus/upgrades-menu/upgrades-menu.component.html
@@ -1,6 +1,6 @@
 <section id="upgradesMenu" class="menu upgrades-menu">
   <div class="tree-zone" #treeWrapper>
-    <p-tabs value="0">
+    <p-tabs [(value)]="activeTab" (valueChange)="onTabChange($event)">
       <p-tablist>
         <p-tab value="0">Upgrades</p-tab>
         @if (this.gameService.game().passivePoints > 0) {


### PR DESCRIPTION
## Summary
- track selected tab for upgrade trees
- switch bounds and pan offset when changing tree

## Testing
- `npm test` *(fails: `ng` not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6859657c1da0832a87a4fd87c3feefb7