### PR TITLE
Move LPS logic to words service

### DIFF
--- a/src/app/Header/wordbox/wordbox.component.ts
+++ b/src/app/Header/wordbox/wordbox.component.ts
@@ -47,10 +47,7 @@ export class WordboxComponent {
   inputValue = model('');
   currentLetterCount = computed(() => this.inputValue().length);
   currentTime = signal(Date.now());
-  lettersPerSecond = signal(0);
-
-  lettersTimestamps: number[] = [];
-  private lastLength = 0;
+  lettersPerSecond = computed(() => this.wordService.lettersPerSecond());
 
   // language: language = 'English ';
 
@@ -61,31 +58,8 @@ export class WordboxComponent {
     //   .subscribe((language) => (this.language = language));
 
     effect(() => {
-      const newLength = this.inputValue().length;
-      const delta = newLength - this.lastLength;
-      const now = Date.now();
-
-      if (delta > 0) {
-        for (let i = 0; i < delta; i++) {
-          this.lettersTimestamps.push(now);
-        }
-      }
-
-      this.lastLength = newLength;
+      this.wordService.recordInputLength(this.inputValue().length);
     });
-
-    setInterval(() => {
-      const now = Date.now();
-      const oneSecondAgo = now - 1000;
-
-      // Filtra timestamps que estén dentro de la última ventana de 1 segundo
-      this.lettersTimestamps = this.lettersTimestamps.filter(
-        (t) => t > oneSecondAgo
-      );
-
-      // Actualiza el signal
-      this.lettersPerSecond.set(this.lettersTimestamps.length);
-    }, 200);
 
     
   }

--- a/src/app/Services/words.service.ts
+++ b/src/app/Services/words.service.ts
@@ -30,10 +30,14 @@ export class WordsService {
   hiraganaWordList: string[] = [];
   russianWordList: string[] = [];
   amharicWordList: string[] = [];
+  lettersPerSecond = signal(0);
+  private lettersTimestamps: number[] = [];
+  private lastInputLength = 0;
 
   constructor() {
     this.loadWordLists();
     setInterval(() => this.updateBonuses(), 100);
+    setInterval(() => this.updateLettersPerSecond(), 200);
   }
 
   private async loadWordLists() {
@@ -119,6 +123,24 @@ export class WordsService {
   masteryService = inject(MasteryService);
   cardService = inject(CardService);
   languageService = inject(LanguageService);
+
+  recordInputLength(length: number) {
+    const delta = length - this.lastInputLength;
+    const now = Date.now();
+    if (delta > 0) {
+      for (let i = 0; i < delta; i++) {
+        this.lettersTimestamps.push(now);
+      }
+    }
+    this.lastInputLength = length;
+  }
+
+  private updateLettersPerSecond() {
+    const now = Date.now();
+    const oneSecondAgo = now - 1000;
+    this.lettersTimestamps = this.lettersTimestamps.filter((t) => t > oneSecondAgo);
+    this.lettersPerSecond.set(this.lettersTimestamps.length);
+  }
 
   private lastWordTime: number = Date.now();
   private lastScrSWordTime = 0;


### PR DESCRIPTION
## Summary
- expose letters-per-second via `WordsService`
- bind the wordbox to the service value

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a808c41e0832a94b63c937592da46